### PR TITLE
69 implement overflow w scroll for project list on chart page

### DIFF
--- a/app/(pages)/(main)/api/page.tsx
+++ b/app/(pages)/(main)/api/page.tsx
@@ -106,14 +106,14 @@ function Endpoint({ title, id, entries }: { title: string, id?: string, entries:
     <div id={id}>
       <h2 className="font-bold">{title}</h2>
       {entries.map((e, i) =>
-        <>
+        <div key={e.url}>
           <div className={i > 0 ? "mt-4" : ""}>
             {e.description}
           </div>
           <span className="bg-green-400 rounded-sm px-1 text-white">{e.method}</span>
           <p className="inline ml-2 bg-slate-600 rounded-sm text-white px-4 font-mono break-all"> {e.url}
           </p>
-        </>
+        </div>
       )}
     </div>
   );

--- a/app/(pages)/globals.css
+++ b/app/(pages)/globals.css
@@ -18,6 +18,17 @@ a {
   box-shadow: 0 -4px 15px 0 rgb(0 0 0 / 0.1)
 }
 
+@layer utilities {
+  .spaced-scrollbar::-webkit-scrollbar {
+    width: 20px;
+}
+.spaced-scrollbar::-webkit-scrollbar-thumb {
+  background: skyblue;
+  background-clip: content-box;
+  border-left: 5px solid transparent;
+}
+}
+
 /* :root {
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;

--- a/app/(pages)/globals.css
+++ b/app/(pages)/globals.css
@@ -25,7 +25,7 @@ a {
 .spaced-scrollbar::-webkit-scrollbar-thumb {
   background: skyblue;
   background-clip: content-box;
-  border-left: 5px solid transparent;
+  border-left: 3px solid transparent;
 }
 }
 

--- a/app/components/ward-spending/DataVis.tsx
+++ b/app/components/ward-spending/DataVis.tsx
@@ -41,7 +41,7 @@ export default function DataVis({
   }
 
   return (
-    <div className="lg:flex lg:gap-x-2">
+    <div className="lg:h-screen lg:flex lg:gap-x-2">
       <div>
         <WardSpendingChart
           data={totals}
@@ -55,7 +55,7 @@ export default function DataVis({
           selectedCategory={selectedCategory}
         />
       </div>
-      <div className="mt-2 lg:mt-0">
+      <div className="h-3/4 overflow-y-auto mt-2 lg:mt-0">
         {selectedCategory ? (
           <ItemDetailList
             spendingItems={detailedSpendingItems}

--- a/app/components/ward-spending/DataVis.tsx
+++ b/app/components/ward-spending/DataVis.tsx
@@ -55,7 +55,7 @@ export default function DataVis({
           selectedCategory={selectedCategory}
         />
       </div>
-      <div className="h-3/4 overflow-y-auto mt-2 lg:mt-0">
+      <div className="mt-2 lg:mt-0">
         {selectedCategory ? (
           <ItemDetailList
             spendingItems={detailedSpendingItems}

--- a/app/components/ward-spending/ItemDetailList.tsx
+++ b/app/components/ward-spending/ItemDetailList.tsx
@@ -17,7 +17,7 @@ export default function ItemDetailList({
   year: number;
 }) {
   return (
-    <div className="mx-2">
+    <div className="w-auto lg:h-3/4 lg:overflow-y-auto mx-2">
       <h2 className="font-bold text-center mb-4">{`${category} Spending in Ward ${ward}, ${year}`}</h2>
       {!!spendingItems.length ? (
         <>

--- a/app/components/ward-spending/ItemDetailList.tsx
+++ b/app/components/ward-spending/ItemDetailList.tsx
@@ -17,7 +17,7 @@ export default function ItemDetailList({
   year: number;
 }) {
   return (
-    <div className="w-auto lg:h-3/4 lg:overflow-y-auto mx-2">
+    <div className="w-auto lg:h-3/4 lg:overflow-y-auto spaced-scrollbar mx-2">
       <h2 className="font-bold text-center mb-4">{`${category} Spending in Ward ${ward}, ${year}`}</h2>
       {!!spendingItems.length ? (
         <>

--- a/app/components/ward-spending/ItemDetailList.tsx
+++ b/app/components/ward-spending/ItemDetailList.tsx
@@ -17,7 +17,7 @@ export default function ItemDetailList({
   year: number;
 }) {
   return (
-    <div>
+    <div className="mx-2">
       <h2 className="font-bold text-center mb-4">{`${category} Spending in Ward ${ward}, ${year}`}</h2>
       {!!spendingItems.length ? (
         <>

--- a/app/components/ward-spending/WardSpendingChart.tsx
+++ b/app/components/ward-spending/WardSpendingChart.tsx
@@ -119,7 +119,7 @@ export default function WardSpendingChart({
 }) {
   const margin = {
     top: -2,
-    right: 32,
+    right: 60,
     bottom: 0,
     left: window.innerWidth < 576 ? 100 : 190,
   };


### PR DESCRIPTION
Added overflow scrolling for (desktop view) spending items.
More work to be done resizing these elements generally (next to-do...), but in the meantime I think this is workable for current page dimensions.